### PR TITLE
Change default Log level to INFO instead of DEBUG

### DIFF
--- a/lib/allure-ruby-adaptor-api.rb
+++ b/lib/allure-ruby-adaptor-api.rb
@@ -8,7 +8,7 @@ module AllureRubyAdaptorApi
       attr_accessor :output_dir, :logging_level
 
       DEFAULT_OUTPUT_DIR = 'gen/allure-results'
-      DEFAULT_LOGGING_LEVEL = Logger::DEBUG
+      DEFAULT_LOGGING_LEVEL = Logger::INFO
 
       def output_dir
         @output_dir || DEFAULT_OUTPUT_DIR


### PR DESCRIPTION
When I use [Allure-Cucumber](https://github.com/allure-framework/allure-cucumber) formatter, **DEBUG** messages spill all over the “_pretty_” print.

I don’t really see any reason to leave it on by default besides when testing changes when developing the adapter itself.

Let me know if it’s better to change on Allure-Cucumber repository, but I think it’s better to change it here.