### PR TITLE
Update builder.rb

### DIFF
--- a/lib/allure-ruby-adaptor-api/builder.rb
+++ b/lib/allure-ruby-adaptor-api/builder.rb
@@ -23,6 +23,7 @@ module AllureRubyAdaptorApi
               :start => timestamp,
               :tests => {},
               :labels => add_default_labels(labels)
+              :attachments => []
           }
         end
       end
@@ -95,7 +96,11 @@ module AllureRubyAdaptorApi
             :size => File.stat(attachment).size
         }
         if step.nil?
-          self.suites[suite][:tests][test][:attachments] << attach
+          unless self.suites[suite][:tests][test].nil?
+            self.suites[suite][:tests][test][:attachments] << attach
+          else
+            self.suites[suite][:attachments] << attach
+          end
         else
           self.suites[suite][:tests][test][:steps][step][:attachments] << attach
         end


### PR DESCRIPTION
When I run RSpec test and I got exception before the test runs, then I can't get attachments of my run. 
I change the code to fix this: if the test is not started, we will add attachments to the suite instead of the test.
This change works on my local.