### PR TITLE
Nokogiri 1.7 dependency update

### DIFF
--- a/allure-ruby-adaptor-api.gemspec
+++ b/allure-ruby-adaptor-api.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_dependency 'nokogiri', '~> 1.6.0'
+  s.add_dependency 'nokogiri', '~> 1.7'
   s.add_dependency 'uuid'
   s.add_dependency 'mimemagic'
 

--- a/allure-ruby-adaptor-api.gemspec
+++ b/allure-ruby-adaptor-api.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.description   = %q{This is a helper library containing the basics for any ruby-based Allure adaptor.}
   s.summary       = "allure-ruby-adaptor-api-#{AllureRubyAdaptorApi::Version::STRING}"
   s.homepage      = 'http://allure.qatools.ru'
-  s.license       = 'Apache2'
+  s.license       = 'Apache-2.0'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {spec,features}/*`.split("\n")

--- a/lib/allure-ruby-adaptor-api/version.rb
+++ b/lib/allure-ruby-adaptor-api/version.rb
@@ -1,6 +1,6 @@
 module AllureRubyAdaptorApi # :nodoc:
   module Version # :nodoc:
-    STRING = '0.6.11'
+    STRING = '0.6.10'
     ALLURE = '1.4.6'
   end
 end

--- a/lib/allure-ruby-adaptor-api/version.rb
+++ b/lib/allure-ruby-adaptor-api/version.rb
@@ -1,6 +1,6 @@
 module AllureRubyAdaptorApi # :nodoc:
   module Version # :nodoc:
-    STRING = '0.6.10'
+    STRING = '0.6.11'
     ALLURE = '1.4.6'
   end
 end

--- a/lib/allure-ruby-adaptor-api/version.rb
+++ b/lib/allure-ruby-adaptor-api/version.rb
@@ -1,6 +1,6 @@
 module AllureRubyAdaptorApi # :nodoc:
   module Version # :nodoc:
-    STRING = '0.6.10'
+    STRING = '0.7.0'
     ALLURE = '1.4.6'
   end
 end


### PR DESCRIPTION
With the release of Ruby 2.4.0p0 there is a depreciation with Fixnum, nokogiri 1.7.0 fixes the depreciation issue.